### PR TITLE
feat: Add category functionality and display

### DIFF
--- a/_includes/category_list.html
+++ b/_includes/category_list.html
@@ -1,0 +1,15 @@
+{% if site.categories.size > 0 %}
+  <div class="category-list">
+    <h3>Categories</h3>
+    <ul>
+      {% for category_array in site.categories %}
+        {% assign category_name = category_array[0] %}
+        <li>
+          <a href="{{ site.baseurl }}/category/{{ category_name | slugify }}/">
+            {{ category_name }}
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+{% endif %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,6 +2,7 @@
 <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}/>
 </head>
 <footer>
+{% include category_list.html %}
 <span class="copy-right-style">
 <p>&nbsp;</p>
 <p>&nbsp;</p>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,6 +7,15 @@ layout: default
   >{{ page.date | date: "%b %-d, %Y" }}{% if page.author %} • {{ page.author }}{% endif %}{% if
   page.meta %} • {{ page.meta }}{% endif %}</time>
 
+{% if page.categories %}
+<div class="post-categories">
+  Categories:
+  {% for category in page.categories %}
+    <a href="{{ site.baseurl }}/category/{{ category | slugify }}/">{{ category }}</a>{% unless forloop.last %}, {% endunless %}
+  {% endfor %}
+</div>
+{% endif %}
+
 {{ content }}
 
 {% if site.disqus.shortname %}


### PR DESCRIPTION
This commit introduces category support to the Jekyll site.

Key changes:
- Modified `_layouts/post.html` to display categories for each post, with links to their respective category archive pages.
- Created `_includes/category_list.html` to generate a list of all unique categories on the site, with each category linking to its archive page.
- Integrated the category list into `_includes/footer.html` so it appears on all pages.
- The `jekyll-archives` plugin is already configured to generate the necessary category pages.

This enhances site navigation and content organization by allowing you to browse posts by category. Guidance has also been provided on how to add categories to individual posts.