### PR TITLE
fix: Correct homepage layout and attempt to enable jekyll-archives

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: default
 title: Home
 ---
 


### PR DESCRIPTION
This commit addresses issues where the homepage was blank and category links were broken (404).

1.  **Homepage (`index.markdown`):**
    *   Changed the front matter layout from `page` to `default`. This aims to ensure the bio content and category links section on the homepage are rendered correctly by using a simpler, more direct layout chain.

2.  **Category Page Generation (`jekyll-archives`):**
    *   Created a `Gemfile` specifying Jekyll, common plugins (minima, jekyll-feed, jekyll-seo-tag, jekyll-paginate, jemoji), and `jekyll-archives`. This is an attempt to ensure `jekyll-archives` is recognized and used during the GitHub Pages build process, which should generate the necessary category archive pages.
    *   If this `Gemfile` alone does not resolve the category page 404s, a custom GitHub Actions workflow will be necessary to build and deploy the site with `jekyll-archives`. Guidance for this has been provided separately.

These changes aim to make the homepage display its content and to have category archive pages generated correctly.