### PR TITLE
feat: Add GitHub Actions workflow for Jekyll deployment

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,45 @@
+name: Build and Deploy Jekyll Site to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master # Assuming 'master' is your publishing branch. Change to 'main' if that's what you use.
+
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7' # This should align with a version compatible with your gems
+          bundler-cache: true # Automatically runs 'bundle install' and caches gems
+
+      - name: Build Jekyll site
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site
+          # If you use a custom domain, uncomment the following line and set your domain
+          # cname: pradeeppant.com 
+          # For organization or user pages (like USERNAME.github.io), 
+          # the deployment usually goes to the 'master' or 'main' branch directly,
+          # or a 'gh-pages' branch if it's a project site.
+          # Given the repo name USERNAME.github.io, it's a user page.
+          # The peaceiris/actions-gh-pages action defaults to deploying to the 'gh-pages' branch.
+          # For user/organization sites, you might need to specify the target branch if it's not gh-pages,
+          # or ensure your GitHub Pages source is set to 'gh-pages' branch.
+          # However, for USERNAME.github.io, pushing to gh-pages is standard for project sites,
+          # but for the root user site, it might expect content on master/main.
+          # Let's assume for now the default behavior of deploying to 'gh-pages' is acceptable,
+          # and the user will set their GitHub Pages source to the 'gh-pages' branch after this runs.
+          # A common alternative for USERNAME.github.io sites is to build and commit directly back to the 'master'/'main' branch.
+          # For simplicity and common practice with this action, we'll stick to `publish_dir: ./_site` which implies `gh-pages` branch.


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to automate the build and deployment of the Jekyll site to GitHub Pages.

The workflow file `.github/workflows/jekyll.yml` is configured to:
- Trigger on pushes to the `master` branch.
- Checkout the repository.
- Set up Ruby and install dependencies from the `Gemfile` (including `jekyll-archives`).
- Build the Jekyll site using `bundle exec jekyll build` with `JEKYLL_ENV=production`.
- Deploy the contents of the `_site` directory to the `gh-pages` branch using the `peaceiris/actions-gh-pages` action.

**Important Next Steps for you:**
1.  After this commit is pushed/merged to `master`, GitHub Actions will attempt to run this workflow.
2.  Monitor the 'Actions' tab in your GitHub repository to see the workflow run.
3.  If the workflow completes successfully, it will deploy your site to a branch named `gh-pages`.
4.  Go to your repository's 'Settings' -> 'Pages'.
5.  Under 'Build and deployment', for 'Source', select 'Deploy from a branch'.
6.  Change the branch from `master` (or `main`) to `gh-pages`, and ensure the folder is set to `/ (root)`. Save changes.

This setup should ensure that `jekyll-archives` and other custom plugins are correctly processed, and category pages (e.g., /category/tech/) will be generated, resolving the 404 errors. Future pushes to `master` will automatically trigger the workflow to rebuild and redeploy the site.